### PR TITLE
Rewrite assertRegexpMatches and assertNotRegexpMatches

### DIFF
--- a/tests/test_teyit.py
+++ b/tests/test_teyit.py
@@ -198,6 +198,14 @@ class TeyitTestCase(unittest.TestCase):
             "self.assertNotAlmostEquals(x, y, z, msg=msg)",
             "self.assertNotAlmostEqual(x, y, z, msg=msg)",
         )
+        self.assertRewrites(
+            "self.assertRegexpMatches(x, y, msg=msg)",
+            "self.assertRegex(x, y, msg=msg)",
+        )
+        self.assertRewrites(
+            "self.assertNotRegexpMatches(x, y, msg=msg)",
+            "self.assertNotRegex(x, y, msg=msg)",
+        )
 
     def test_assert_rewriter_cosmetic(self):
         for case in (TEST_DATA_DIR / "cosmetic").iterdir():

--- a/teyit.py
+++ b/teyit.py
@@ -39,6 +39,8 @@ DEPRECATED_ALIASES = {
     "failIfAlmostEqual": "assertNotAlmostEqual",
     "failUnlessAlmostEqual": "assertAlmostEqual",
     "assertNotAlmostEquals": "assertNotAlmostEqual",
+    "assertRegexpMatches": "assertRegex",
+    "assertNotRegexpMatches": "assertNotRegex",
 }
 
 


### PR DESCRIPTION
Deprecated since Python 3.2: 

* `assertRegexpMatches`
* `assertNotRegexpMatches`
* https://docs.python.org/3.10/library/unittest.html#deprecated-aliases

Removed in Python 3.11:

* https://docs.python.org/3.11/whatsnew/3.11.html#removed

---

These are also removed in 3.11 but not part of this PR:

Deprecated since 3.1:

* `failUnlessRaises`

And since 3.2:

* `assertRaisesRegexp`
* `assertDictContainsSubset`

I wasn't sure if they can be included? `*Raises*` are usually called with a context manager. And `assertDictContainsSubset` needs some argument juggling: https://stackoverflow.com/a/59777678/724176.
