### PR TITLE
Rewrite `assert` statements, refs #12

### DIFF
--- a/ex.py
+++ b/ex.py
@@ -1,3 +1,0 @@
-class TestSome:
-    def testMe(self):
-        self.assertEqual(1, 1)

--- a/ex.py
+++ b/ex.py
@@ -1,0 +1,3 @@
+class TestSome:
+    def testMe(self):
+        self.assertEqual(1, 1)

--- a/tests/cosmetic/assert_statements/input.py
+++ b/tests/cosmetic/assert_statements/input.py
@@ -1,0 +1,27 @@
+import unittest
+
+
+class NotACase:
+    def not_a_case(self):
+        assert 1 == 2
+
+
+class WrongTestCase(unittest.TestCase):
+    def not_a_case(self):
+        assert isinstance(1, int)
+
+    def test_without_self():
+        assert 3 is 4  # comment
+
+
+class CorrectTestCase(unittest.TestCase):
+    def test_regular(self):
+        assert self is not None  # comment
+        assert isinstance(
+            self,  # this is
+            unittest.TestCase,  # multiline
+        )
+        assert 1 == 1  # eq
+
+    assert True
+assert True

--- a/tests/cosmetic/assert_statements/output.py
+++ b/tests/cosmetic/assert_statements/output.py
@@ -1,0 +1,27 @@
+import unittest
+
+
+class NotACase:
+    def not_a_case(self):
+        assert 1 == 2
+
+
+class WrongTestCase(unittest.TestCase):
+    def not_a_case(self):
+        assert isinstance(1, int)
+
+    def test_without_self():
+        assert 3 is 4  # comment
+
+
+class CorrectTestCase(unittest.TestCase):
+    def test_regular(self):
+        self.assertIsNotNone(self)
+        self.assertIsInstance(
+            self, # this is
+            unittest.TestCase
+        )
+        self.assertEqual(1, 1)
+
+    assert True
+assert True

--- a/teyit.py
+++ b/teyit.py
@@ -206,13 +206,17 @@ class _AssertRewriter(ast.NodeVisitor):
 
     def visit_ClassDef(self, node):
         for child_node in ast.walk(node):
-            if not isinstance(child_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not isinstance(
+                child_node, (ast.FunctionDef, ast.AsyncFunctionDef)
+            ):
                 continue
 
-            if not _looks_like_test(node.name) or not _looks_like_test(child_node.name):
+            if not _looks_like_test(node.name) or not _looks_like_test(
+                child_node.name
+            ):
                 continue
 
-            if not any(arg.arg == 'self' for arg in child_node.args.args):
+            if not any(arg.arg == "self" for arg in child_node.args.args):
                 continue
 
             visitor = _AssertStmtFinder()
@@ -220,22 +224,26 @@ class _AssertRewriter(ast.NodeVisitor):
 
             for assert_stmt in visitor.stmts:
                 # with suppress(Exception):
-                new_expr = self.visit_assertTrue(ast.Call(
-                    ast.Attribute(
-                        ast.Name('self', ast.Load),
-                        'assertTrue',
-                        ast.Load,
-                    ),
-                    [assert_stmt.test],
-                    [],  # TODO: support `msg` part
-                ))
+                new_expr = self.visit_assertTrue(
+                    ast.Call(
+                        ast.Attribute(
+                            ast.Name("self", ast.Load),
+                            "assertTrue",
+                            ast.Load,
+                        ),
+                        [assert_stmt.test],
+                        [],  # TODO: support `msg` part
+                    )
+                )
                 if new_expr is None:
                     continue
 
-                self.asserts.append(AssertStmtRewrite(
-                    node=assert_stmt,
-                    expr=new_expr,
-                ))
+                self.asserts.append(
+                    AssertStmtRewrite(
+                        node=assert_stmt,
+                        expr=new_expr,
+                    )
+                )
         self.generic_visit(node)
 
 
@@ -250,7 +258,7 @@ class _AssertStmtFinder(ast.NodeVisitor):
 
 
 def _looks_like_test(name):
-    return 'test' in name or 'Test' in name
+    return "test" in name or "Test" in name
 
 
 class _FormattedUnparser(PreciseUnparser):


### PR DESCRIPTION
This is still a WIP.

I have several questions:
1. How does `get_arg_offset` suppose to work? I am bit a lost with this approach 🙂 
2. Do we need to handle `msg` part of `assert expr, msg`? Because not all `self.assert*()` methods support it

Closes #12