### PR TITLE
Pre-commit hook: python3 instead of python3.9

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
     description: 'Unittest assertion formatter'
     entry: teyit
     language: python
-    language_version: python3.9
+    language_version: python3
     types: [python]


### PR DESCRIPTION
I'm mostly using Python 3.10 locally and for CI linting, and currently it fails like this:

```
[INFO] Initializing environment for https://github.com/asottile/pyupgrade.
[INFO] Initializing environment for https://github.com/PyCQA/isort.
[INFO] Initializing environment for https://github.com/isidentical/teyit.
[INFO] Initializing environment for https://github.com/pre-commit/pygrep-hooks.
[INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/isidentical/teyit.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/home/runner/work/tablib/tablib/.tox/lint/bin/python', '-mvirtualenv', '/home/runner/.cache/pre-commit/repostlq81p2/py_env-python3.9', '-p', 'python3.9')
return code: 1
expected return code: 0
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.9'
    
stderr: (none)
Check the log at /home/runner/.cache/pre-commit/pre-commit.log
ERROR: InvocationError for command /home/runner/work/tablib/tablib/.tox/lint/bin/pre-commit run --all-files (exited with code 3)
```

Setting just `python3` should be enough. For example, compare https://github.com/PyCQA/isort/blob/c6a41965247a858a0afd848fbebfca18b8983917/.pre-commit-hooks.yaml.