### PR TITLE
Lint: Update Black to fix Click

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,19 +5,19 @@ exclude: '^tests/cosmetic/'
 
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
+-   repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
     hooks:
     -   id: isort
 -   repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.20.0
+    rev: v1.20.1
     hooks:
     -   id: setup-cfg-fmt
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.931'
+    rev: 'v0.942'
     hooks:
       -  id: mypy
          args:
@@ -26,14 +26,14 @@ repos:
          -   --disable-error-code
          -   attr-defined
 -   repo: https://github.com/hakancelik96/unimport
-    rev: 0.9.4
+    rev: 0.9.5
     hooks:
       - id: unimport
         args:
         -   --remove
         -   --ignore-init
--   repo: https://github.com/executablebooks/mdformat/
-    rev: 0.7.13
+-   repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.14
     hooks:
     -   id: mdformat
         additional_dependencies:


### PR DESCRIPTION
Run `pre-commit autoupdate` to get the latest Black version which fixes a Click incompatibility: 

* https://github.com/isidentical/teyit/runs/5807530020?check_suite_focus=true

Also use isort repo directly, the mirror is now deprecated.